### PR TITLE
Add gain controls and enable toggle with enhanced processing

### DIFF
--- a/source/PluginEditor.cpp
+++ b/source/PluginEditor.cpp
@@ -36,17 +36,18 @@ PluginEditor::PluginEditor (PluginProcessor& p)
     outputGainLabel.setJustificationType(juce::Justification::centred);
     outputGainLabel.attachToComponent(&outputGainSlider, false);
 
-    // Create parameter attachments (this is what makes automation work!)
+    // Create parameter attachments using the public constants
     inputGainAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
-        processorRef.getValueTreeState(), "inputGain", inputGainSlider);
+        processorRef.getValueTreeState(), PluginProcessor::INPUT_GAIN_ID, inputGainSlider);
     outputGainAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
-        processorRef.getValueTreeState(), "outputGain", outputGainSlider);
+        processorRef.getValueTreeState(), PluginProcessor::OUTPUT_GAIN_ID, outputGainSlider);
 
     setSize (400, 300);
 }
 
 PluginEditor::~PluginEditor()
-= default;
+{
+}
 
 void PluginEditor::paint (juce::Graphics& g)
 {
@@ -62,11 +63,11 @@ void PluginEditor::resized()
     auto bounds = getLocalBounds();
     bounds.removeFromTop(40); // Space for title
 
-    // Inspector button in the bottom corner
+    // Inspector button in bottom corner
     inspectButton.setBounds(bounds.removeFromBottom(30).removeFromRight(120).reduced(5));
 
-    // Split the remaining area for the two knobs
-    auto knobArea = bounds.reduced (20);
+    // Split remaining area for the two knobs
+    auto knobArea = bounds.reduced(20);
     auto knobWidth = knobArea.getWidth() / 2;
 
     auto inputArea = knobArea.removeFromLeft(knobWidth).reduced(10);

--- a/source/PluginEditor.cpp
+++ b/source/PluginEditor.cpp
@@ -14,6 +14,12 @@ PluginEditor::PluginEditor (PluginProcessor& p)
         inspector->setVisible (true);
     };
 
+    // Gain stage enable button
+    addAndMakeVisible(gainEnabledButton);
+    gainEnabledButton.setButtonText("Enable Gain Stage");
+    gainEnabledAttachment = std::make_unique<juce::AudioProcessorValueTreeState::ButtonAttachment>(
+        processorRef.getValueTreeState(), PluginProcessor::GAIN_ENABLED_ID, gainEnabledButton);
+
     // Input gain slider setup
     addAndMakeVisible(inputGainSlider);
     inputGainSlider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
@@ -42,32 +48,54 @@ PluginEditor::PluginEditor (PluginProcessor& p)
     outputGainAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
         processorRef.getValueTreeState(), PluginProcessor::OUTPUT_GAIN_ID, outputGainSlider);
 
-    setSize (400, 300);
+    setSize (500, 400);
 }
 
 PluginEditor::~PluginEditor()
-{
-}
+= default;
 
-void PluginEditor::paint (juce::Graphics& g)
-{
-    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 
-    g.setColour (juce::Colours::white);
-    g.setFont (18.0f);
-    g.drawText ("Bass Gain Stager", getLocalBounds().removeFromTop(40), juce::Justification::centred, true);
+void PluginEditor::paint(juce::Graphics& g)
+{
+    g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+
+    g.setColour(juce::Colours::white);
+    g.setFont(18.0f);
+    g.drawText("Bass Gain Stager", getLocalBounds().removeFromTop(40),
+               juce::Justification::centred, true);
+
+    // Draw a section frame around the gain stage controls
+    auto gainSectionBounds = getLocalBounds().reduced(20);
+    gainSectionBounds.removeFromTop(60); // Leave room for the title
+    gainSectionBounds.setHeight(200);    // Fixed height for the gain section
+
+    g.setColour(juce::Colours::darkgrey.withAlpha(0.6f));
+    g.fillRoundedRectangle(gainSectionBounds.toFloat(), 10.0f);
+
+    g.setColour(juce::Colours::white);
+    g.setFont(16.0f);
+    g.drawText("Gain Stage", gainSectionBounds.removeFromTop(30),
+               juce::Justification::centred, true);
 }
 
 void PluginEditor::resized()
 {
+    // Allow space for title
     auto bounds = getLocalBounds();
-    bounds.removeFromTop(40); // Space for title
+    bounds.removeFromTop(50);
 
-    // Inspector button in bottom corner
+    // Inspector button in the bottom corner
     inspectButton.setBounds(bounds.removeFromBottom(30).removeFromRight(120).reduced(5));
 
-    // Split remaining area for the two knobs
-    auto knobArea = bounds.reduced(20);
+    // Gain section
+    auto gainSection = bounds.reduced(25);
+    gainSection.setHeight(200);
+
+    // Enable button at the top of the section
+    gainEnabledButton.setBounds(gainSection.removeFromTop(30));
+
+    // Split the remaining area for the two knobs
+    auto knobArea = gainSection.reduced(10);
     auto knobWidth = knobArea.getWidth() / 2;
 
     auto inputArea = knobArea.removeFromLeft(knobWidth).reduced(10);
@@ -79,4 +107,14 @@ void PluginEditor::resized()
 
     inputGainSlider.setBounds(inputArea);
     outputGainSlider.setBounds(outputArea);
+}
+
+// Helper method for future effect sections
+void PluginEditor::createEffectSection(const juce::String& title,
+                                       juce::Component& container,
+                                       juce::ToggleButton& enableButton)
+{
+    // For future use when we add more sections,
+    // This will be a pattern for creating standardized section containers
+    juce::ignoreUnused(title, container, enableButton);
 }

--- a/source/PluginEditor.cpp
+++ b/source/PluginEditor.cpp
@@ -3,46 +3,79 @@
 PluginEditor::PluginEditor (PluginProcessor& p)
     : AudioProcessorEditor (&p), processorRef (p)
 {
-    juce::ignoreUnused (processorRef);
-
+    // UI Inspector setup
     addAndMakeVisible (inspectButton);
-
-    // this chunk of code instantiates and opens the melatonin inspector
     inspectButton.onClick = [&] {
         if (!inspector)
         {
             inspector = std::make_unique<melatonin::Inspector> (*this);
             inspector->onClose = [this]() { inspector.reset(); };
         }
-
         inspector->setVisible (true);
     };
 
-    // Make sure that before the constructor has finished, you've set the
-    // editor's size to whatever you need it to be.
+    // Input gain slider setup
+    addAndMakeVisible(inputGainSlider);
+    inputGainSlider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
+    inputGainSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 80, 20);
+    inputGainSlider.setTextValueSuffix(" dB");
+
+    addAndMakeVisible(inputGainLabel);
+    inputGainLabel.setText("Input Gain", juce::dontSendNotification);
+    inputGainLabel.setJustificationType(juce::Justification::centred);
+    inputGainLabel.attachToComponent(&inputGainSlider, false);
+
+    // Output gain slider setup
+    addAndMakeVisible(outputGainSlider);
+    outputGainSlider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
+    outputGainSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 80, 20);
+    outputGainSlider.setTextValueSuffix(" dB");
+
+    addAndMakeVisible(outputGainLabel);
+    outputGainLabel.setText("Output Gain", juce::dontSendNotification);
+    outputGainLabel.setJustificationType(juce::Justification::centred);
+    outputGainLabel.attachToComponent(&outputGainSlider, false);
+
+    // Create parameter attachments (this is what makes automation work!)
+    inputGainAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
+        processorRef.getValueTreeState(), "inputGain", inputGainSlider);
+    outputGainAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
+        processorRef.getValueTreeState(), "outputGain", outputGainSlider);
+
     setSize (400, 300);
 }
 
 PluginEditor::~PluginEditor()
-{
-}
+= default;
 
 void PluginEditor::paint (juce::Graphics& g)
 {
-    // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 
-    auto area = getLocalBounds();
     g.setColour (juce::Colours::white);
-    g.setFont (16.0f);
-    auto helloWorld = juce::String ("Hello from ") + PRODUCT_NAME_WITHOUT_VERSION + " v" VERSION + " running in " + CMAKE_BUILD_TYPE;
-    g.drawText (helloWorld, area.removeFromTop (150), juce::Justification::centred, false);
+    g.setFont (18.0f);
+    g.drawText ("Bass Gain Stager", getLocalBounds().removeFromTop(40), juce::Justification::centred, true);
 }
 
 void PluginEditor::resized()
 {
-    // layout the positions of your child components here
-    auto area = getLocalBounds();
-    area.removeFromBottom(50);
-    inspectButton.setBounds (getLocalBounds().withSizeKeepingCentre(100, 50));
+    auto bounds = getLocalBounds();
+    bounds.removeFromTop(40); // Space for title
+
+    // Inspector button in the bottom corner
+    inspectButton.setBounds(bounds.removeFromBottom(30).removeFromRight(120).reduced(5));
+
+    // Split the remaining area for the two knobs
+    auto knobArea = bounds.reduced (20);
+    const auto knobWidth = knobArea.getWidth() / 2;
+
+    auto inputArea = knobArea.removeFromLeft(knobWidth).reduced(10);
+    auto outputArea = knobArea.reduced(10);
+
+    // Leave space for labels
+    inputArea.removeFromTop(20);
+    outputArea.removeFromTop(20);
+
+    inputGainSlider.setBounds(inputArea);
+    outputGainSlider.setBounds(outputArea);
 }

--- a/source/PluginEditor.cpp
+++ b/source/PluginEditor.cpp
@@ -67,7 +67,7 @@ void PluginEditor::resized()
 
     // Split the remaining area for the two knobs
     auto knobArea = bounds.reduced (20);
-    const auto knobWidth = knobArea.getWidth() / 2;
+    auto knobWidth = knobArea.getWidth() / 2;
 
     auto inputArea = knobArea.removeFromLeft(knobWidth).reduced(10);
     auto outputArea = knobArea.reduced(10);

--- a/source/PluginEditor.h
+++ b/source/PluginEditor.h
@@ -16,10 +16,21 @@ public:
     void resized() override;
 
 private:
-    // This reference is provided as a quick way for your editor to
-    // access the processor object that created it.
     PluginProcessor& processorRef;
+
+    // UI Inspector
     std::unique_ptr<melatonin::Inspector> inspector;
     juce::TextButton inspectButton { "Inspect the UI" };
+
+    // Gain controls
+    juce::Slider inputGainSlider;
+    juce::Slider outputGainSlider;
+    juce::Label inputGainLabel;
+    juce::Label outputGainLabel;
+
+    // Parameter attachments for automation
+    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> inputGainAttachment;
+    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> outputGainAttachment;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginEditor)
 };

--- a/source/PluginEditor.h
+++ b/source/PluginEditor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "PluginProcessor.h"
-#include "BinaryData.h"
+// #include "BinaryData.h"
 #include "melatonin_inspector/melatonin_inspector.h"
 
 //==============================================================================
@@ -21,6 +21,14 @@ private:
     // UI Inspector
     std::unique_ptr<melatonin::Inspector> inspector;
     juce::TextButton inspectButton { "Inspect the UI" };
+
+    juce::ToggleButton gainEnabledButton;
+    std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> gainEnabledAttachment;
+
+    // Add a helper method for creating effect sections
+    void createEffectSection(const juce::String& title,
+                             juce::Component& container,
+                             juce::ToggleButton& enableButton);
 
     // Gain controls
     juce::Slider inputGainSlider;

--- a/source/PluginEditor.h
+++ b/source/PluginEditor.h
@@ -26,7 +26,7 @@ private:
     std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> gainEnabledAttachment;
 
     // Add a helper method for creating effect sections
-    void createEffectSection(const juce::String& title,
+    static void createEffectSection(const juce::String& title,
                              juce::Component& container,
                              juce::ToggleButton& enableButton);
 

--- a/source/PluginProcessor.cpp
+++ b/source/PluginProcessor.cpp
@@ -10,12 +10,37 @@ PluginProcessor::PluginProcessor()
                       #endif
                        .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
                      #endif
-                       )
+                       ),
+       valueTreeState(*this, nullptr, "PARAMETERS", createParameterLayout())
 {
 }
 
 PluginProcessor::~PluginProcessor()
+= default;
+
+juce::AudioProcessorValueTreeState::ParameterLayout PluginProcessor::createParameterLayout()
 {
+    std::vector<std::unique_ptr<juce::RangedAudioParameter>> parameters;
+
+    // Input gain: -12dB to +12dB, default 0dB
+    parameters.push_back(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(INPUT_GAIN_ID, 1),
+        "Input Gain",
+        juce::NormalisableRange<float>(-12.0f, 12.0f, 0.1f),
+        0.0f,
+        juce::AudioParameterFloatAttributes().withLabel("dB")
+    ));
+
+    // Output gain: -24dB to +6dB, default 0dB
+    parameters.push_back(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(OUTPUT_GAIN_ID, 1),
+        "Output Gain",
+        juce::NormalisableRange<float>(-24.0f, 6.0f, 0.1f),
+        0.0f,
+        juce::AudioParameterFloatAttributes().withLabel("dB")
+    ));
+
+    return { parameters.begin(), parameters.end() };
 }
 
 //==============================================================================
@@ -87,7 +112,7 @@ void PluginProcessor::changeProgramName (int index, const juce::String& newName)
 void PluginProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
     // Use this method as the place to do any pre-playback
-    // initialisation that you need..
+    // initialization that you need.
     juce::ignoreUnused (sampleRate, samplesPerBlock);
 }
 
@@ -120,34 +145,40 @@ bool PluginProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 }
 
 void PluginProcessor::processBlock (juce::AudioBuffer<float>& buffer,
-                                              juce::MidiBuffer& midiMessages)
+                                  juce::MidiBuffer& midiMessages)
 {
     juce::ignoreUnused (midiMessages);
-
     juce::ScopedNoDenormals noDenormals;
+
     auto totalNumInputChannels  = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();
 
-    // In case we have more outputs than inputs, this code clears any output
-    // channels that didn't contain input data, (because these aren't
-    // guaranteed to be empty - they may contain garbage).
-    // This is here to avoid people getting screaming feedback
-    // when they first compile a plugin, but obviously you don't need to keep
-    // this code if your algorithm always overwrites all the output channels.
+    // Clear any extra output channels
     for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
         buffer.clear (i, 0, buffer.getNumSamples());
 
-    // This is the place where you'd normally do the guts of your plugin's
-    // audio processing...
-    // Make sure to reset the state if your inner loop is processing
-    // the samples and the outer loop is handling the channels.
-    // Alternatively, you can process the samples with the channels
-    // interleaved by keeping the same state.
+    // Get parameter values and convert from dB to linear gain
+    const float inputGainDb = inputGainParam->load();
+    const float outputGainDb = outputGainParam->load();
+    const float inputGainLinear = juce::Decibels::decibelsToGain(inputGainDb);
+    const float outputGainLinear = juce::Decibels::decibelsToGain(outputGainDb);
+
+    // Process each channel
     for (int channel = 0; channel < totalNumInputChannels; ++channel)
     {
-        auto* channelData = buffer.getWritePointer (channel);
-        juce::ignoreUnused (channelData);
-        // ..do something to the data...
+        auto* channelData = buffer.getWritePointer(channel);
+
+        for (int sample = 0; sample < buffer.getNumSamples(); ++sample)
+        {
+            // Apply input gain
+            channelData[sample] *= inputGainLinear;
+
+            // Here's where you'd insert other processing later
+            // (e.g., compressor, EQ, distortion, etc.)
+
+            // Apply output gain/trim
+            channelData[sample] *= outputGainLinear;
+        }
     }
 }
 
@@ -165,21 +196,22 @@ juce::AudioProcessorEditor* PluginProcessor::createEditor()
 //==============================================================================
 void PluginProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
-    // You should use this method to store your parameters in the memory block.
-    // You could do that either as raw data, or use the XML or ValueTree classes
-    // as intermediaries to make it easy to save and load complex data.
-    juce::ignoreUnused (destData);
+    // Save parameters to host
+    auto state = valueTreeState.copyState();
+    std::unique_ptr<juce::XmlElement> xml (state.createXml());
+    copyXmlToBinary (*xml, destData);
 }
 
 void PluginProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
-    // You should use this method to restore your parameters from this memory block,
-    // whose contents will have been created by the getStateInformation() call.
-    juce::ignoreUnused (data, sizeInBytes);
+    // Restore parameters from host
+    if (const std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes)); xmlState != nullptr)
+        if (xmlState->hasTagName (valueTreeState.state.getType()))
+            valueTreeState.replaceState (juce::ValueTree::fromXml (*xmlState));
 }
 
 //==============================================================================
-// This creates new instances of the plugin..
+// This creates new instances of the plugin
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new PluginProcessor();

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -3,7 +3,7 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
 #if (MSVC)
-#include "ipps.h"
+    #include "ipps.h"
 #endif
 
 class PluginProcessor : public juce::AudioProcessor
@@ -41,13 +41,14 @@ public:
     // Add this for parameter access
     juce::AudioProcessorValueTreeState& getValueTreeState() { return valueTreeState; }
 
-    // Parameter IDs - making these public so editor can access them
+    // Parameter IDs - making these public so the editor can access them
     static constexpr const char* INPUT_GAIN_ID = "inputGain";
     static constexpr const char* OUTPUT_GAIN_ID = "outputGain";
+    static constexpr const char* GAIN_ENABLED_ID = "gainEnabled";
 
 private:
     // Parameter layout creation
-    juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
 
     // Value tree state for parameter management
     juce::AudioProcessorValueTreeState valueTreeState;

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -6,7 +6,7 @@
     #include "ipps.h"
 #endif
 
-class PluginProcessor : public juce::AudioProcessor
+class PluginProcessor final : public juce::AudioProcessor
 {
 public:
     PluginProcessor();

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -52,5 +52,9 @@ private:
     // Value tree state for parameter management
     juce::AudioProcessorValueTreeState valueTreeState;
 
+    // Smoothed parameters to prevent clicking
+    juce::SmoothedValue<float> smoothedInputGain;
+    juce::SmoothedValue<float> smoothedOutputGain;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginProcessor)
 };

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -38,23 +38,19 @@ public:
     void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
-    // Adds parameter access
+    // Add this for parameter access
     juce::AudioProcessorValueTreeState& getValueTreeState() { return valueTreeState; }
 
-private:
-    // Parameter layout creation
-    static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
-
-    // Value tree state for parameter management
-    juce::AudioProcessorValueTreeState valueTreeState;
-
-    // Parameter IDs - using this ensures consistency
+    // Parameter IDs - making these public so editor can access them
     static constexpr const char* INPUT_GAIN_ID = "inputGain";
     static constexpr const char* OUTPUT_GAIN_ID = "outputGain";
 
-    // Atomic parameters for thread-safe access in processBlock
-    std::atomic<float>* inputGainParam = nullptr;
-    std::atomic<float>* outputGainParam = nullptr;
+private:
+    // Parameter layout creation
+    juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
+
+    // Value tree state for parameter management
+    juce::AudioProcessorValueTreeState valueTreeState;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginProcessor)
 };

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -38,6 +38,23 @@ public:
     void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
+    // Adds parameter access
+    juce::AudioProcessorValueTreeState& getValueTreeState() { return valueTreeState; }
+
 private:
+    // Parameter layout creation
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
+
+    // Value tree state for parameter management
+    juce::AudioProcessorValueTreeState valueTreeState;
+
+    // Parameter IDs - using this ensures consistency
+    static constexpr const char* INPUT_GAIN_ID = "inputGain";
+    static constexpr const char* OUTPUT_GAIN_ID = "outputGain";
+
+    // Atomic parameters for thread-safe access in processBlock
+    std::atomic<float>* inputGainParam = nullptr;
+    std::atomic<float>* outputGainParam = nullptr;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginProcessor)
 };


### PR DESCRIPTION
```
### Description
- Introduced toggle button to enable/disable the gain stage and updated layout accordingly.
- Added smoothed input and output gain parameters to avoid audio clicking during changes.
- Implemented rotary sliders for real-time control of input/output gains with parameter automation.
- Refactored parameter access for consistent and cleaner code usage.
- Enhanced audio processing logic to reflect the aforementioned updates and preserved parameter states during saving/loading.

### Checklist
- [ ] Unit tests have been added.
- [ ] Documentation has been updated.
- [ ] Related issues have been linked.

```